### PR TITLE
feat: Snapshot delegation subgraph on base

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This subgraph indexes the data from the Snapshot delegation contracts.
 
 - Create a new file similar to `subgraph.sepolia.yaml`
 - Find `startBlock` of contract on new network
+- Update `startBlock` and `network` with new values
 - Create a new script in package.json similar to `deploy-studio-sepolia`
 
 ### How to deploy to studio

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "graph build",
     "deploy-studio": "graph deploy --studio snapshot",
     "deploy-studio-sepolia": "graph deploy --studio snapshot-sepolia subgraph.sepolia.yaml",
+    "deploy-studio-base": "graph deploy --studio snapshot-base subgraph.base.yaml",
     "deploy": "graph deploy snapshot-labs/snapshot --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy-goerli": "graph deploy snapshot-labs/snapshot-goerli subgraph.goerli.yaml --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy-kovan": "graph deploy snapshot-labs/snapshot-kovan subgraph.kovan.yaml --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",

--- a/subgraph.base.yaml
+++ b/subgraph.base.yaml
@@ -1,0 +1,28 @@
+specVersion: 0.0.4
+description: Snapshot subgraph
+repository: https://github.com/snapshot-labs/snapshot-subgraph
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: DelegateRegistry
+    network: sepolia
+    source:
+      address: '0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446'
+      abi: DelegateRegistry
+      startBlock: 17894724
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Delegation
+      abis:
+        - name: DelegateRegistry
+          file: ./abis/DelegateRegistry.json
+      eventHandlers:
+        - event: SetDelegate(indexed address,indexed bytes32,indexed address)
+          handler: handleSetDelegate
+        - event: ClearDelegate(indexed address,indexed bytes32,indexed address)
+          handler: handleClearDelegate
+      file: ./src/mapping.ts

--- a/subgraph.base.yaml
+++ b/subgraph.base.yaml
@@ -6,7 +6,7 @@ schema:
 dataSources:
   - kind: ethereum/contract
     name: DelegateRegistry
-    network: sepolia
+    network: base
     source:
       address: '0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446'
       abi: DelegateRegistry


### PR DESCRIPTION
Add snapshot delegation subgraph to base

# TODO:
- Run `yarn codegen` to generate the types for the subgraph
- Run `yarn build` to build the subgraph
- Run `yarn deploy-studio-base --deploy-key=<DEPLOY_CODE_HERE>`