### PR TITLE
feat: Add base-sepolia subgraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "deploy-studio": "graph deploy --studio snapshot",
     "deploy-studio-sepolia": "graph deploy --studio snapshot-sepolia subgraph.sepolia.yaml",
     "deploy-studio-base": "graph deploy --studio snapshot-base subgraph.base.yaml",
+    "deploy-studio-base-sepolia": "graph deploy --studio snapshot-base-sepolia subgraph.base-sepolia.yaml",
     "deploy-studio-blast-mainnet": "graph deploy --studio snapshot-blast-mainnet subgraph.blast-mainnet.yaml",
     "deploy-studio-linea": "graph deploy --studio snapshot-linea subgraph.linea.yaml",
     "deploy": "graph deploy snapshot-labs/snapshot --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",

--- a/subgraph.base-sepolia.yaml
+++ b/subgraph.base-sepolia.yaml
@@ -1,0 +1,28 @@
+specVersion: 0.0.4
+description: Snapshot subgraph
+repository: https://github.com/snapshot-labs/snapshot-subgraph
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: DelegateRegistry
+    network: base-sepolia
+    source:
+      address: '0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446'
+      abi: DelegateRegistry
+      startBlock: 18221646
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Delegation
+      abis:
+        - name: DelegateRegistry
+          file: ./abis/DelegateRegistry.json
+      eventHandlers:
+        - event: SetDelegate(indexed address,indexed bytes32,indexed address)
+          handler: handleSetDelegate
+        - event: ClearDelegate(indexed address,indexed bytes32,indexed address)
+          handler: handleClearDelegate
+      file: ./src/mapping.ts


### PR DESCRIPTION
Add snapshot delegation subgraph to base-sepolia

TODO:
- Run yarn codegen to generate the types for the subgraph
- Run yarn build to build the subgraph
- Run yarn deploy-studio-base-sepolia --deploy-key=<DEPLOY_CODE_HERE>
- [x] Allow new subgraph on API key https://thegraph.com/studio/apikeys/