### PR TITLE
deploy: mantle subgraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "deploy-arbitrum-one": "graph deploy snapshot-labs/snapshot-arbitrum-one subgraph.arbitrum-one.yaml --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy-fantom": "graph deploy snapshot-labs/snapshot-fantom subgraph.fantom.yaml --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
     "deploy-optimism": "graph deploy snapshot-labs/snapshot-optimism subgraph.optimism.yaml --ipfs https://api.thegraph.com/ipfs/ --node https://api.thegraph.com/deploy/",
+    "deploy-mantle": "graph deploy snapshot-labs/snapshot-mantle subgraph.mantle.yaml --node https://subgraph-api.mantle.xyz/deploy --ipfs https://subgraph-api.mantle.xyz/ipfs",
     "deploy-local": "graph deploy snapshot-labs/snapshot --ipfs http://localhost:5001 --node http://127.0.0.1:8020"
   },
   "devDependencies": {

--- a/subgraph.mantle.yaml
+++ b/subgraph.mantle.yaml
@@ -1,0 +1,30 @@
+specVersion: 0.0.2
+description: Snapshot subgraph
+repository: https://github.com/snapshot-labs/snapshot-subgraph
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum/contract
+    name: DelegateRegistry
+    network: mantle
+    source:
+      address: '0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446'
+      abi: DelegateRegistry
+      startBlock: 75529389
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Delegation
+      abis:
+        - name: DelegateRegistry
+          file: ./abis/DelegateRegistry.json
+      eventHandlers:
+        - event: SetDelegate(indexed address,indexed bytes32,indexed address)
+          handler: handleSetDelegate
+        - event: ClearDelegate(indexed address,indexed bytes32,indexed address)
+          handler: handleClearDelegate
+      file: ./src/mapping.ts
+
+


### PR DESCRIPTION
TODO:

Run yarn codegen to generate the types for the subgraph
Run yarn build to build the subgraph
Go to https://subgraph.mantle.xyz/dashboard/api and create a key 
Run yarn deploy-mantle --deploy-key=<DEPLOY_CODE_HERE>
